### PR TITLE
Provide predictions outside of observed values

### DIFF
--- a/src/base/simulator.rs
+++ b/src/base/simulator.rs
@@ -1,5 +1,7 @@
 use crate::base::datafile::Scenario;
 use interp::interp_slice;
+use std::{collections::HashSet, iter};
+
 pub trait Simulate {
     fn simulate(
         &self,
@@ -41,5 +43,50 @@ where
             ));
         }
         y_intrp.into_iter().flatten().collect::<Vec<f64>>()
+    }
+
+    pub fn pred_full(&self, scenario: &Scenario, params: Vec<f64>, dt: f64) -> Vec<(f64, f64)> {
+        let start_time = *scenario.time.first().unwrap();
+        let end_time = *scenario.time.last().unwrap();
+
+        // Generate custom_times based on the given interval (dt)
+        let predicted_times: Vec<f64> = iter::successors(Some(start_time), |t| Some(t + dt))
+            .take_while(|t| *t <= end_time)
+            .collect();
+
+        // Concatenate observed times with predicted times
+        let custom_times: Vec<f64> = scenario
+            .time_flat
+            .iter()
+            .chain(predicted_times.iter())
+            .cloned()
+            .collect();
+
+        let (x_out, y_out) = self.sim.simulate(params, [start_time, end_time], scenario);
+
+        let y_intrp: Vec<Vec<f64>> = y_out
+            .iter()
+            .map(|out| interp_slice(&x_out, out, &custom_times))
+            .collect();
+
+        let predictions: Vec<(f64, f64)> = custom_times
+            .into_iter()
+            .zip(y_intrp.into_iter().flatten())
+            .collect();
+
+        // Filter out duplicate rows by time
+        let mut unique_predictions = Vec::new();
+        let mut seen_times = HashSet::new();
+        for (time, value) in predictions {
+            let time_int = (time * 1000000.0) as i64;
+            if seen_times.insert(time_int) {
+                unique_predictions.push((time, value));
+            }
+        }
+
+        // Sort the predictions by time (ascending)
+        unique_predictions.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+
+        unique_predictions
     }
 }


### PR DESCRIPTION
Working example, but needs refactoring. Should consider to use a different approach for pop values, instead of repeating for length of posterior parameter values.
The times should also be considered to be added to the Scenarios object, instead of doing it in an external function.

Depends on how we intend to handle multiple outeq, for which the Scenario method may be more suitable and flexible.