### PR TITLE
Setting for more predictions

### DIFF
--- a/examples/bimodal_ke/config.toml
+++ b/examples/bimodal_ke/config.toml
@@ -11,6 +11,7 @@ seed = 347
 tui = true
 pmetrics_outputs = true
 cache = true
+idelta = 0.1
 
 [random]
 Ke = [0.001, 3.0]

--- a/examples/bimodal_ke/main.rs
+++ b/examples/bimodal_ke/main.rs
@@ -89,6 +89,9 @@ impl<'a> Predict<'a> for Ode {
         time: f64,
         next_time: f64,
     ) -> State {
+        if time == next_time {
+            return x;
+        }
         let mut stepper = Dopri5::new(system, time, next_time, 1e-3, x, RTOL, ATOL);
         let _res = stepper.integrate();
         let y = stepper.y_out();

--- a/src/entrypoints.rs
+++ b/src/entrypoints.rs
@@ -73,8 +73,9 @@ where
     log::info!("Total time: {:.2?}", now.elapsed());
 
     let idelta = settings.parsed.config.idelta.unwrap_or(0.0);
+    let tad = settings.parsed.config.tad.unwrap_or(0.0);
     if let Some(write) = &settings.parsed.config.pmetrics_outputs {
-        result.write_outputs(*write, &engine, idelta);
+        result.write_outputs(*write, &engine, idelta, tad);
     }
 
     Ok(result)

--- a/src/entrypoints.rs
+++ b/src/entrypoints.rs
@@ -72,8 +72,9 @@ where
     let result = algorithm.fit();
     log::info!("Total time: {:.2?}", now.elapsed());
 
+    let idelta = settings.parsed.config.idelta.unwrap_or(0.0);
     if let Some(write) = &settings.parsed.config.pmetrics_outputs {
-        result.write_outputs(*write, &engine);
+        result.write_outputs(*write, &engine, idelta);
     }
 
     Ok(result)

--- a/src/routines/datafile.rs
+++ b/src/routines/datafile.rs
@@ -22,6 +22,70 @@ impl Scenario {
         Ok(scenario)
     }
 
+    pub fn add_event_interval(&self, interval: f64) -> Self {
+        // Clone the underlying Event data instead of the references
+        let all_events = self
+            .clone()
+            .blocks
+            .iter()
+            .flat_map(|block| block.events.iter().cloned())
+            .collect::<Vec<_>>();
+
+        // Determine the start and end times
+        let start_time = all_events.first().unwrap().time;
+        let end_time = all_events.last().unwrap().time;
+
+        // Determine the unique output equations in the events
+        // TODO: This should be read from the model / engine
+        let mut outeqs: Vec<_> = all_events.iter().filter_map(|event| event.outeq).collect();
+        outeqs.sort_unstable();
+        outeqs.dedup();
+
+        // Generate dummy events
+        let mut new_events = vec![];
+        let mut current_time = start_time + interval; // Start from the first interval after the start time
+        while current_time < end_time {
+            current_time = (current_time / interval).round() * interval; // Round to the nearest interval
+            current_time = decimals(current_time, 4); // Round to 4 decimal places
+            for outeq in &outeqs {
+                new_events.push(Event {
+                    id: self.id.clone(),
+                    evid: 0,
+                    time: current_time,
+                    dur: None,
+                    dose: None,
+                    _addl: None,
+                    _ii: None,
+                    input: None,
+                    out: Some(-99.0),
+                    outeq: Some(*outeq),
+                    _c0: None,
+                    _c1: None,
+                    _c2: None,
+                    _c3: None,
+                    covs: HashMap::new(),
+                });
+            }
+            current_time += interval;
+        }
+
+        // Combine all_events with new_events
+        let mut combined_events = all_events;
+        combined_events.extend(new_events.iter().cloned());
+
+        // Sort the events by time
+        combined_events.sort_by(|a, b| a.cmp_by_id_then_time(b));
+        // Remove duplicate events based on time and outeq
+        // In essence, no need to have two predictions at the same time for the same outeq
+        let time_tolerance = 1e-4;
+        combined_events.sort_by(|a, b| a.cmp_by_id_then_time(b));
+        combined_events.dedup_by(|a, b| {
+            (a.time - b.time).abs() < time_tolerance && a.outeq == b.outeq && a.evid == b.evid
+        });
+
+        Scenario::new(combined_events).unwrap()
+    }
+
     pub fn reorder_with_lag(&self, lag_inputs: Vec<(f64, usize)>) -> Self {
         if lag_inputs.is_empty() {
             return self.clone();
@@ -300,4 +364,9 @@ fn check_obs(event: &Event) -> Result<(), Box<dyn Error>> {
         exit(-1);
     }
     Ok(())
+}
+
+fn decimals(value: f64, places: u32) -> f64 {
+    let multiplier = 10f64.powi(places as i32);
+    (value * multiplier).round() / multiplier
 }

--- a/src/routines/datafile.rs
+++ b/src/routines/datafile.rs
@@ -22,7 +22,10 @@ impl Scenario {
         Ok(scenario)
     }
 
-    pub fn add_event_interval(&self, interval: f64) -> Self {
+    /// Adds "mock" events to a Scenario in order to generate predictions at those times
+    /// The interval is mapped to the `idelta`-setting in the configuration time
+    /// Time after dose (tad) will ensure that predictions are made until the last dose + tad
+    pub fn add_event_interval(&self, interval: f64, tad: f64) -> Self {
         // Clone the underlying Event data instead of the references
         let all_events = self
             .clone()
@@ -33,7 +36,20 @@ impl Scenario {
 
         // Determine the start and end times
         let start_time = all_events.first().unwrap().time;
-        let end_time = all_events.last().unwrap().time;
+        let mut end_time = all_events.last().unwrap().time;
+
+        // Pad end time to accomodate time after dose
+        if tad > 0.0{
+            let last_dose_time = all_events
+                .iter()
+                .filter(|event| event.evid == 1)
+                .map(|event| event.time)
+                .fold(std::f64::NEG_INFINITY, f64::max);
+
+            if end_time < last_dose_time + tad {
+                end_time = last_dose_time + tad
+            }
+        }
 
         // Determine the unique output equations in the events
         // TODO: This should be read from the model / engine
@@ -44,7 +60,7 @@ impl Scenario {
         // Generate dummy events
         let mut new_events = vec![];
         let mut current_time = start_time + interval; // Start from the first interval after the start time
-        while current_time < end_time {
+        while current_time <= end_time {
             current_time = (current_time / interval).round() * interval; // Round to the nearest interval
             current_time = decimals(current_time, 4); // Round to 4 decimal places
             for outeq in &outeqs {

--- a/src/routines/output.rs
+++ b/src/routines/output.rs
@@ -55,7 +55,7 @@ impl NPResult {
         }
     }
 
-    pub fn write_outputs<'a, S>(&self, write: bool, engine: &Engine<S>, idelta: f64)
+    pub fn write_outputs<'a, S>(&self, write: bool, engine: &Engine<S>, idelta: f64, tad: f64)
     where
         S: Predict<'static> + std::marker::Sync + 'static + Clone + std::marker::Send,
     {
@@ -63,7 +63,7 @@ impl NPResult {
             self.write_theta();
             self.write_posterior();
             self.write_obs();
-            self.write_pred(&engine, idelta);
+            self.write_pred(&engine, idelta, tad);
             self.write_meta();
         }
     }
@@ -178,7 +178,7 @@ impl NPResult {
     }
 
     /// Writes the predictions
-    pub fn write_pred<'a, S>(&self, engine: &Engine<S>, idelta: f64)
+    pub fn write_pred<'a, S>(&self, engine: &Engine<S>, idelta: f64, tad: f64)
     where
         S: Predict<'static> + std::marker::Sync + std::marker::Send + 'static + Clone,
     {
@@ -187,7 +187,7 @@ impl NPResult {
             // Add an event interval to each scenario
             if idelta > 0.0 {
                 scenarios.iter_mut().for_each(|scenario| {
-                    *scenario = scenario.add_event_interval(idelta);
+                    *scenario = scenario.add_event_interval(idelta, tad);
                 });
             }
 

--- a/src/routines/settings/run.rs
+++ b/src/routines/settings/run.rs
@@ -64,6 +64,7 @@ pub struct Config {
     pub exclude: Option<Array>,
     pub cache: Option<bool>,
     pub idelta: Option<f64>,
+    pub tad: Option<f64>,
 }
 
 pub fn read(filename: String) -> Data {

--- a/src/routines/settings/run.rs
+++ b/src/routines/settings/run.rs
@@ -63,6 +63,7 @@ pub struct Config {
     pub pmetrics_outputs: Option<bool>,
     pub exclude: Option<Array>,
     pub cache: Option<bool>,
+    pub idelta: Option<f64>,
 }
 
 pub fn read(filename: String) -> Data {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -93,8 +93,8 @@ pub fn start_ui(mut rx: UnboundedReceiver<NPCycle>, settings: Data) -> Result<()
     terminal.show_cursor()?;
     crossterm::terminal::disable_raw_mode()?;
     terminal
-            .draw(|rect| draw(rect, &app, &app_history, elapsed_time, &settings))
-            .unwrap();
+        .draw(|rect| draw(rect, &app, &app_history, elapsed_time, &settings))
+        .unwrap();
     Ok(())
 }
 


### PR DESCRIPTION
Implements add_event_interval for Scenario, which will add new events for predictions. Currently used in the `write_pred()`-function, with new argument `idelta`, which is read from the setting of the same name,